### PR TITLE
Otterdog/blueprint/require dependabot auto merge

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,10 +1,12 @@
+# This is a templated file from https://github.com/adoptium/.eclipsefdn/tree/main/otterdog/policies/require_dependabot_auto_merge.yml
 name: Dependabot auto-merge
 on: pull_request_target
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: read-all
 
 jobs:
   dependabot:
+    permissions:
+      contents: write
+      pull-requests: write
     uses: adoptium/.github/.github/workflows/dependabot-auto-merge.yml@main

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,5 +1,4 @@
-# This is a templated file from 
-https://github.com/adoptium/.eclipsefdn/tree/main/otterdog/blueprints/require_dependabot_auto_merge.yml
+# This is a templated file from https://github.com/adoptium/.eclipsefdn/tree/main/otterdog/blueprints/require_dependabot_auto_merge.yml
 name: Dependabot auto-merge
 on: pull_request_target
 

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,4 +1,5 @@
-# This is a templated file from https://github.com/adoptium/.eclipsefdn/tree/main/otterdog/policies/require_dependabot_auto_merge.yml
+# This is a templated file from 
+https://github.com/adoptium/.eclipsefdn/tree/main/otterdog/blueprints/require_dependabot_auto_merge.yml
 name: Dependabot auto-merge
 on: pull_request_target
 


### PR DESCRIPTION
### Description

In this pull request, the permissions configuration for the Dependabot auto-merge GitHub Actions workflow has been updated to align with a template file sourced from adoptium/.eclipsefdn. 

Changes:
- Permissions configuration has been updated to only grant read access.
- Within the 'dependabot' job, permissions for 'contents' and 'pull-requests' have been explicitly set to 'write'.

These modifications ensure appropriate access rights for the Dependabot auto-merge GitHub Actions workflow.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Update the dependabot auto-merge GitHub Actions workflow to use a templated file and adjust permissions configuration.

### Why are these changes being made?
These changes align the workflow file with the standardized template from the Adoptium organization's Otterdog blueprint to ensure a consistent setup. Adjustments to permissions allow the workflow to perform necessary actions with the appropriate access rights.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->